### PR TITLE
Implement log search navigation

### DIFF
--- a/src/autotrain/app/static/scripts/logs.js
+++ b/src/autotrain/app/static/scripts/logs.js
@@ -1,5 +1,7 @@
 document.addEventListener('DOMContentLoaded', function () {
     var fetchLogsInterval;
+    var searchMatches = [];
+    var currentMatchIndex = -1;
 
     // Function to check the modal's display property and fetch logs if visible
     function fetchAndDisplayLogs() {
@@ -21,27 +23,58 @@ document.addEventListener('DOMContentLoaded', function () {
         }
     }
 
+    function highlightMatch(index) {
+        var logContainer = document.getElementById('logContent');
+        logContainer.querySelectorAll('.bg-yellow-200').forEach(el => {
+            el.classList.remove('bg-yellow-200');
+        });
+        if (searchMatches.length === 0) return;
+        var el = searchMatches[index];
+        el.classList.add('bg-yellow-200');
+        el.scrollIntoView({ block: 'center' });
+    }
+
+    function updateSearchResults() {
+        var query = document.getElementById('logSearchInput').value.toLowerCase();
+        searchMatches = [];
+        currentMatchIndex = -1;
+        var logContainer = document.getElementById('logContent');
+        var logElements = logContainer.querySelectorAll('p');
+        logElements.forEach(el => {
+            el.classList.remove('bg-yellow-200');
+            if (query && el.textContent.toLowerCase().includes(query)) {
+                searchMatches.push(el);
+            }
+        });
+        if (searchMatches.length > 0) {
+            currentMatchIndex = 0;
+            highlightMatch(currentMatchIndex);
+        }
+    }
+
     // Function to fetch logs from the server
     function fetchLogs() {
         fetch('/ui/logs')
             .then(response => response.json())
             .then(data => {
                 var logContainer = document.getElementById('logContent');
-                logContainer.innerHTML = ''; // Clear previous logs
+                logContainer.innerHTML = '';
 
-                // Handling the case when logs are only available in local mode or no logs available
                 if (typeof data.logs === 'string') {
                     logContainer.textContent = data.logs;
                 } else {
-                    // Assuming data.logs is an array of log entries
                     data.logs.forEach(log => {
                         if (log.trim().length > 0) {
                             var p = document.createElement('p');
                             p.textContent = log;
-                            logContainer.appendChild(p); // Appends logs in order received
+                            if (log.toLowerCase().includes('error')) {
+                                p.classList.add('text-red-600', 'dark:text-red-400');
+                            }
+                            logContainer.appendChild(p);
                         }
                     });
                 }
+                updateSearchResults();
             })
             .catch(error => console.error('Error fetching logs:', error));
     }
@@ -58,5 +91,17 @@ document.addEventListener('DOMContentLoaded', function () {
     var modal = document.getElementById('logs-modal');
     observer.observe(modal, {
         attributes: true //configure it to listen to attribute changes
+    });
+
+    document.getElementById('logSearchInput').addEventListener('input', updateSearchResults);
+    document.getElementById('logNextBtn').addEventListener('click', function () {
+        if (searchMatches.length === 0) return;
+        currentMatchIndex = (currentMatchIndex + 1) % searchMatches.length;
+        highlightMatch(currentMatchIndex);
+    });
+    document.getElementById('logPrevBtn').addEventListener('click', function () {
+        if (searchMatches.length === 0) return;
+        currentMatchIndex = (currentMatchIndex - 1 + searchMatches.length) % searchMatches.length;
+        highlightMatch(currentMatchIndex);
     });
 });

--- a/src/autotrain/app/templates/index.html
+++ b/src/autotrain/app/templates/index.html
@@ -604,6 +604,14 @@
                 </button>
                 <div class="p-6 md:p-8 text-center">
                     <h3 class="mb-5 text-lg font-medium text-gray-900 dark:text-gray-100">Logs</h3>
+                    <div class="flex items-center justify-center mb-2">
+                        <input id="logSearchInput" type="text" placeholder="Search..."
+                            class="p-1 text-xs border border-gray-300 dark:border-gray-600 rounded mr-2 dark:bg-gray-700">
+                        <button id="logPrevBtn"
+                            class="px-2 py-1 text-xs border border-gray-300 dark:border-gray-600 rounded mr-1">Prev</button>
+                        <button id="logNextBtn"
+                            class="px-2 py-1 text-xs border border-gray-300 dark:border-gray-600 rounded">Next</button>
+                    </div>
                     <div id="logContent"
                         class="text-xs font-normal text-left overflow-y-auto max-h-[calc(100vh-400px)] border-t border-gray-200 dark:border-gray-700 pt-4">
                         <!-- Logs will be appended here -->

--- a/src/autotrain/app/utils.py
+++ b/src/autotrain/app/utils.py
@@ -1,10 +1,10 @@
 import os
 import signal
 import sys
+from typing import Any, Dict
 
 import psutil
 import requests
-from typing import Any, Dict
 
 from autotrain import config, logger
 


### PR DESCRIPTION
## Summary
- add search UI controls to log modal
- implement search, next & previous navigation for logs
- highlight lines containing 'error' in red text in both light and dark modes

## Testing
- `make quality` *(fails: flake8 not installed)*
- `make test` *(fails: ModuleNotFoundError: No module named 'loguru')*

------
https://chatgpt.com/codex/tasks/task_e_683e2add62b8832d830fa82cdfc9e0af